### PR TITLE
Added external APIs to retrieve weather and flight info

### DIFF
--- a/travelpal/lib/travelpal_web/controllers/flight_controller.ex
+++ b/travelpal/lib/travelpal_web/controllers/flight_controller.ex
@@ -1,0 +1,70 @@
+defmodule TravelpalWeb.FlightController do
+  use TravelpalWeb, :controller
+
+  # @TODO decide if other functions are needed
+  def flight_url, do: "https://api.skypicker.com/flights"
+
+  def get_flights_to_from(conn, %{"origin" => origin, "dest" => dest, "date_from" => date_from, "return_from" => return_from}) do
+    # gets top 5 flights
+    uri = URI.encode(flight_url() <> "?flyFrom=#{origin}&to=#{dest}&date_from=#{date_from}&date_to=#{date_from}"
+        <> "&return_from=#{return_from}&return_to=#{return_from}&partner=picky&partner_market=us&limit=5")
+    
+    # comment out HTTP request for dev purposes and use dummy data instead
+    #res = HTTPoison.get!(uri)
+    #data = Poison.decode!(res.body)
+
+    # use dummy data for dev purposes
+    #flight = data["data"]
+    # @TODO decide if more details are needed
+    flight = dummy_data()
+    |> Enum.map(fn(x) -> Map.take(x, ["price", "mapIdfrom", "mapIdto", "airlines", "duration", "deep_link"]) end)
+    |> Poison.encode!()
+
+    render(conn, "show.json", flight: flight)
+  end
+
+  def dummy_data do
+    [
+      %{
+        "airlines" => ["AS", "UA"],
+        "deep_link" => "https://www.kiwi.com/deep?from=BOS&to=LAX&departure=05-08-2018&return=05-12-2018&flightsId=3571213871549614_0%7C3927455603931439_0&price=320&passengers=1&affilid=picky&lang=en&currency=EUR&booking_token=TjFsU9KOyjpEDqm5dNSrO1ZjuRMVMgZrERrSppD325T6P8+P9w468E+3gYirNKm0xjFEaQ8brFkJXYHcFnHHQMiKg0Dkoaiav5UhUit795jeFFAqEo1EKVZuez5O1ueoor1vahBPhrpq/0WADMhABtY5vdWSberiYk61VFIJMRp4s6ZSzHyNgbNckdTqU7qdfZpRqVJEtW6IRWoeCiw1GPFDI+Hw1yLpRfB1ptE7vlW9tkkPUjw697wUdcL4Yx28aUCVJRBrCA/L3FNex/RY6mOqHthZ8JQWOD6Y0YUjhUwPGmJACX0xuu88UBNWGVbG3f9HTq2CpG5Ia7H1eZs+S+5Zbl9TxM1P/0iyFcvHGI0DEZeHss34gti+hRSv2W+DDTTJeq1SPB6fOVj+rGl20MF+nQmjjpqw86rcq6cG5Fi706sm7iciWAjIhCba7quYWYzIotUE40rtoc7GuSrSZCk3uO4zcygslqkHcKfisWyMazFn4mEAp3zeWxi8yxSNtZoH+CIGLxT4z/9MizxZQB4ScDmb/ogmDP77vENDVNPOYBVb3hQ0a4sqe8h0na2ExjcDaiubr0TK8M0xCv07UwMl7ZzZCpun4o1ca+H1SKu6cb9FgpHUe1mHfiPB6acjuL7K9kr1hdvIpo3aE24koYDcxxkHFAkgQB6O2L/qCUPQYRurE9MdVAOH8gnVaY0O54TPTy4XBAjKuhCRyE4NrnsNxM8UYnbZfH6XXYs4rCI=",
+        "duration" => %{"departure" => 22800, "return" => 19200, "total" => 42000},
+        "mapIdfrom" => "boston",
+        "mapIdto" => "los-angeles",
+        "price" => 320
+      },
+      %{
+        "airlines" => ["UA"],
+        "deep_link" => "https://www.kiwi.com/deep?from=BOS&to=LAX&departure=05-08-2018&return=05-12-2018&flightsId=3571213871549614_0%7C3927455603931456_0&price=325&passengers=1&affilid=picky&lang=en&currency=EUR&booking_token=TjFsU9KOyjpEDqm5dNSrO1ZjuRMVMgZrERrSppD325T6P8+P9w468E+3gYirNKm0xjFEaQ8brFkJXYHcFnHHQMiKg0Dkoaiav5UhUit795jeFFAqEo1EKVZuez5O1ueoor1vahBPhrpq/0WADMhABsNgYFl6+I3dolcFf1aYOhd5FWWXwuRJe9ikXvBVbMk+e4GKjkaF4Vpskiu4iSnDOtLXxRq4e6Koez41GFv9AUb20oJyW10aNHVubuKQ4wWsjH1SJESYhRkW41LukQW6zVdhv3vy87KMyVIeqHDl29MjfODm4DD5Eh/DXS8kniKxnRmYc98FqOVwYcJ00HQlQ7hDCuQqMFcOLy3xP8Z/WZr2B+ERWf5LHrQW2rqrmrt6ZfPxXmKj6NwfXoW7yRLXycnAGtZ+475S0naK+4Gus6NEeEQU9gINyci/mXU6RseKZqT5k1KpZr5347QCZacM3TkzEx8kGXSO/hBC56/XMiN5BdeA6ry0PSMi1MiSXvdxjpoPfurPD26SjrD4+2BBtyUD03NdAyx1Wg7WO5cpoXSJgc/D7QXErGV5hBd4NfJL1HvVhFvqB5Kcxm/rs8QqPJN78xRpJ+dH1PO8wNRqoh6U4DcD6BTsTFlgqxCSRW7ANxq0rXPStOI11K8X3idIUcLlIdqmkBQlJPxUjlCf8IYe5aXzHXLxDjqQyUBlcCojyoG1TImPfDMo9K2Cr0LQFxA1Y4jshr5YCBiyd5dZMkw=",
+        "duration" => %{"departure" => 22800, "return" => 19380, "total" => 42180},
+        "mapIdfrom" => "boston",
+        "mapIdto" => "los-angeles",
+        "price" => 325
+      },
+      %{
+        "airlines" => ["B6", "AS"],
+        "deep_link" => "https://www.kiwi.com/deep?from=BOS&to=LAX&departure=05-08-2018&return=05-12-2018&flightsId=4009918922031857_0%7C3927455603931439_0&price=332&passengers=1&affilid=picky&lang=en&currency=EUR&booking_token=TjFsU9KOyjpEDqm5dNSrO1ZjuRMVMgZrERrSppD325T6P8+P9w468E+3gYirNKm0xjFEaQ8brFkJXYHcFnHHQMiKg0Dkoaiav5UhUit795hBYuJzs+k6wEGHRjVL9Zv8lp9myBwP9GcVua7Ntk87g/+DM9IctVZOLLGnmqSjVXsf/AglmEU2VkenIE+uUBUG7WAXklFR/y3jX5lBAHz1UlN3B74dTgXwFwqdHu58uor4oumUZlMVWBt6PfOhzsxpDqkRyptBrVWZMuy/qNVI2Dl7Eb7/dbxgL831nAgm2m+P8VpjKZS06+vlfCoosN3s5OKmV8PQVVNCeZlJBgSsJYbnMyU+Zreb677OZhPWNPUCcjlksMQ7tBpJjv7S4H46vFMz+4MCUcj392tHsZAfvYUXJ1TQ/Z3Wm5iVxbsFGDK+GdwXcH/B1mHUl2XMENHae/Q+Xmnjj4wa4dZrway9tghEOqvX0z3+1qTbdHsjyySYHGb3FCCdQbSfZYRywK+Iqy0YLLB3l4guXpb1fNkeje/RhnM2R1kYY8tnJ6+O3sqqXWtLU8dP2ftolfBNQ0N3CsTBdhsIQJYWXWMfmuXwFHnEk2MWqwcXbgv6jBPq+Ic1T1c/IhuyfLWz/oKgH7GXyTkRKEAzWCoGkUmBgpXQrQfHUgObyLE/Vs7zbOM/9+jVmLfglG4YFot60YfJG9KpiCmWFrivUlNyLMvBuK7SFzZ5cqLakX+lLiZHbsnrv2w=",
+        "duration" => %{"departure" => 22920, "return" => 19200, "total" => 42120},
+        "mapIdfrom" => "boston",
+        "mapIdto" => "los-angeles",
+        "price" => 332
+      },
+      %{
+        "airlines" => ["B6", "UA"],
+        "deep_link" => "https://www.kiwi.com/deep?from=BOS&to=LAX&departure=05-08-2018&return=05-12-2018&flightsId=4009918922031857_0%7C3927455603931456_0&price=337&passengers=1&affilid=picky&lang=en&currency=EUR&booking_token=TjFsU9KOyjpEDqm5dNSrO1ZjuRMVMgZrERrSppD325T6P8+P9w468E+3gYirNKm0xjFEaQ8brFkJXYHcFnHHQMiKg0Dkoaiav5UhUit795hBYuJzs+k6wEGHRjVL9Zv8lp9myBwP9GcVua7Ntk87gyS9g5huQ4UdmwW152QhCnNMyLkVrkshDBUTu8WelhUZTIzgimnWncfchd9VAyIDMYKEDIBPH/BmNOufqD0DQqoa/Dr6ygsH0iXVdMb5Meu15Rb4I7Xh2bkGl01lUwpbgBnRk+xxeaBaRsOXppsmrDPf1R/leBTuIuPr8dfUHcQjUcISqU3RxmgBS41t/4oNUlIDmuRFsNWsUCUQu+Ng80x0YkVsqLpCr9/zzWiw7uynQmIp35KilIMWrEraqUaOPZKxz0xozIEG5XzhA7zSXp2BGfikNiXEzprg0gYZ4jAuV+uyd2DhBp0rhGO0yJPgFKp38U8NtsdTjFn46YsIT4/Fy0j8XzlrBQXN5AErD0uvtvmfxxvLvdgDoUkffw7mLW3b1aAH7QAdZjDJqn/lJouuvY0bMSS0C5hFg6BJGaeQBynwsylQ9513e+LNt+O2fFErUBLg2LUtjJMPG4oL2yGxtRPTHjPB2rGYTlL0mcc2ogRanv1kNcKKaszknuXRU8ZQxEE2Ov0CTi72OneBUZGMRiGNm/v2CCa2Fo10T97e8tCvijjk84ZEvGDWeAmEDGTWPkkeHABYd1U2kK9poA4=",
+        "duration" => %{"departure" => 22920, "return" => 19380, "total" => 42300},
+        "mapIdfrom" => "boston",
+        "mapIdto" => "los-angeles",
+        "price" => 337
+      },
+      %{
+        "airlines" => ["UA"],
+        "deep_link" => "https://www.kiwi.com/deep?from=BOS&to=LAX&departure=05-08-2018&return=05-12-2018&flightsId=3571213871549614_0%7C3927455603931455_0&price=339&passengers=1&affilid=picky&lang=en&currency=EUR&booking_token=TjFsU9KOyjpEDqm5dNSrO1ZjuRMVMgZrERrSppD325T6P8+P9w468E+3gYirNKm0xjFEaQ8brFkJXYHcFnHHQMiKg0Dkoaiav5UhUit795jeFFAqEo1EKVZuez5O1ueoor1vahBPhrpq/0WADMhABvHnmXSeLHXmqbHdVEIaINKtythSQJmhEg/NnxhvNJQ36QHa1RqubK9+OTIxdr+PI2YqGpGP0m13Rtu+yC+j7uEMUAzso15/amal0m/npELyg0CfLJmSMMVLKQfcYuxpBAuIH2qR+5O2bi5+BmOIkfOEOAjU20P55A1xI+fHrXkUxXVbiziB+HLR60HzIMvdifP9NhlNHyRuC1VWjvE6MgjNCHJNE233UU0yc1iyrNwdwzXpekbulNpgi2787u3P4C1Jg+597Lc4eDlVAuAsyIdGZxZjuB2SQRwiy3b0RM6crb7GgOv6G559ezgNGZva/o3ti/dWGffPL1gUzgtWka+5aNoGCfKdzBaXc+MW9CM37aPbFMW1l0I8jP23Y0r/6jZ5NaZN5S1V4r2mgfJQomE8r+GLfw2EkWHFyTrDIDo48xRAgWMwioLV3ICNUOUXe7TIJxVtLfwjqDLlMDLXRM3v1pd3i75PI7LwfMqWWKfSC3veuIHAyL5ihnvmUBY+7p1v+P/UExKkWAGEEsh7jExuskFegaD1pm3VHSjr/eNCdh32VdRnfMl9ebPvVqQbyURkJzagWXsL6V+AwnBoEIg=",
+        "duration" => %{"departure" => 22800, "return" => 19380, "total" => 42180},
+        "mapIdfrom" => "boston",
+        "mapIdto" => "los-angeles",
+        "price" => 339
+      }
+    ]
+  end
+end

--- a/travelpal/lib/travelpal_web/controllers/flight_controller.ex
+++ b/travelpal/lib/travelpal_web/controllers/flight_controller.ex
@@ -7,7 +7,7 @@ defmodule TravelpalWeb.FlightController do
   def get_flights_to_from(conn, %{"origin" => origin, "dest" => dest, "date_from" => date_from, "return_from" => return_from}) do
     # gets top 5 flights
     uri = URI.encode(flight_url() <> "?flyFrom=#{origin}&to=#{dest}&date_from=#{date_from}&date_to=#{date_from}"
-        <> "&return_from=#{return_from}&return_to=#{return_from}&partner=picky&partner_market=us&limit=5")
+        <> "&return_from=#{return_from}&return_to=#{return_from}&partner=picky&partner_market=us&curr=USD&limit=5")
     
     # comment out HTTP request for dev purposes and use dummy data instead
     #res = HTTPoison.get!(uri)

--- a/travelpal/lib/travelpal_web/controllers/weather_controller.ex
+++ b/travelpal/lib/travelpal_web/controllers/weather_controller.ex
@@ -1,0 +1,50 @@
+defmodule TravelpalWeb.WeatherController do
+  use TravelpalWeb, :controller
+
+  # @TODO decide if other functions are needed
+  def weather_url, do: "https://query.yahooapis.com/v1/public/yql"
+
+  def get_weather_by_city(conn, %{"city" => city}) do
+    # relevant columns from the weather table
+    columns = ["units", "location", "item"]
+    |> Enum.join(", ")
+    # Yahoo Weather API uses YSQL to specify data
+    ysql_query = "SELECT #{columns} FROM weather.forecast WHERE woeid in (SELECT woeid FROM geo.places(1) WHERE text=\"#{city}\")"
+    uri = URI.encode(weather_url() <> "?q=#{ysql_query}&format=json")
+    # comment out HTTP request for dev purposes and use dummy data instead
+    #res = HTTPoison.get!(uri)
+    res = dummy_data()
+    data = Poison.decode!(res.body)
+
+    # retrieves the relevant weather details and encodes it as JSON
+    weather = data["query"]["results"]["channel"]
+    |> Poison.encode!()
+
+    render(conn, "show.json", weather: weather)
+  end
+
+  def dummy_data do
+    %HTTPoison.Response{
+      body: "{\"query\":{\"count\":1,\"created\":\"2018-04-12T04:03:38Z\",\"lang\":\"en-US\",\"results\":{\"channel\":{\"location\":{\"city\":\"Boston\",\"country\":\"United States\",\"region\":\" MA\"},\"item\":{\"title\":\"Conditions for Boston, MA, US at 11:00 PM EDT\",\"lat\":\"42.358631\",\"long\":\"-71.056702\",\"link\":\"http://us.rd.yahoo.com/dailynews/rss/weather/Country__Country/*https://weather.yahoo.com/country/state/city-2367105/\",\"pubDate\":\"Wed, 11 Apr 2018 11:00 PM EDT\",\"condition\":{\"code\":\"31\",\"date\":\"Wed, 11 Apr 2018 11:00 PM EDT\",\"temp\":\"38\",\"text\":\"Clear\"},\"forecast\":[{\"code\":\"11\",\"date\":\"12 Apr 2018\",\"day\":\"Thu\",\"high\":\"53\",\"low\":\"38\",\"text\":\"Showers\"},{\"code\":\"30\",\"date\":\"13 Apr 2018\",\"day\":\"Fri\",\"high\":\"64\",\"low\":\"49\",\"text\":\"Partly Cloudy\"},{\"code\":\"28\",\"date\":\"14 Apr 2018\",\"day\":\"Sat\",\"high\":\"63\",\"low\":\"44\",\"text\":\"Mostly Cloudy\"},{\"code\":\"11\",\"date\":\"15 Apr 2018\",\"day\":\"Sun\",\"high\":\"43\",\"low\":\"40\",\"text\":\"Showers\"},{\"code\":\"47\",\"date\":\"16 Apr 2018\",\"day\":\"Mon\",\"high\":\"57\",\"low\":\"44\",\"text\":\"Scattered Thunderstorms\"},{\"code\":\"28\",\"date\":\"17 Apr 2018\",\"day\":\"Tue\",\"high\":\"48\",\"low\":\"41\",\"text\":\"Mostly Cloudy\"},{\"code\":\"30\",\"date\":\"18 Apr 2018\",\"day\":\"Wed\",\"high\":\"52\",\"low\":\"38\",\"text\":\"Partly Cloudy\"},{\"code\":\"30\",\"date\":\"19 Apr 2018\",\"day\":\"Thu\",\"high\":\"52\",\"low\":\"44\",\"text\":\"Partly Cloudy\"},{\"code\":\"30\",\"date\":\"20 Apr 2018\",\"day\":\"Fri\",\"high\":\"51\",\"low\":\"42\",\"text\":\"Partly Cloudy\"},{\"code\":\"30\",\"date\":\"21 Apr 2018\",\"day\":\"Sat\",\"high\":\"52\",\"low\":\"42\",\"text\":\"Partly Cloudy\"}],\"description\":\"<![CDATA[<img src=\\\"http://l.yimg.com/a/i/us/we/52/31.gif\\\"/>\\n<BR />\\n<b>Current Conditions:</b>\\n<BR />Clear\\n<BR />\\n<BR />\\n<b>Forecast:</b>\\n<BR /> Thu - Showers. High: 53Low: 38\\n<BR /> Fri - Partly Cloudy. High: 64Low: 49\\n<BR /> Sat - Mostly Cloudy. High: 63Low: 44\\n<BR /> Sun - Showers. High: 43Low: 40\\n<BR /> Mon - Scattered Thunderstorms. High: 57Low: 44\\n<BR />\\n<BR />\\n<a href=\\\"http://us.rd.yahoo.com/dailynews/rss/weather/Country__Country/*https://weather.yahoo.com/country/state/city-2367105/\\\">Full Forecast at Yahoo! Weather</a>\\n<BR />\\n<BR />\\n<BR />\\n]]>\",\"guid\":{\"isPermaLink\":\"false\"}},\"units\":{\"distance\":\"mi\",\"pressure\":\"in\",\"speed\":\"mph\",\"temperature\":\"F\"}}}}}",
+      headers: [
+        {"X-Content-Type-Options", "nosniff"},
+        {"Access-Control-Allow-Origin", "*"},
+        {"Content-Type", "application/json;charset=utf-8"},
+        {"Cache-Control", "no-cache"},
+        {"Date", "Thu, 12 Apr 2018 04:03:38 GMT"},
+        {"Age", "0"},
+        {"Transfer-Encoding", "chunked"},
+        {"Connection", "keep-alive"},
+        {"Strict-Transport-Security", "max-age=31536000"},
+        {"Via", "http/1.1 a34.ue.bf1.yahoo.net (ApacheTrafficServer [cMsSf ])"},
+        {"Server", "ATS"},
+        {"Public-Key-Pins-Report-Only",
+        "max-age=2592000; pin-sha256=\"2oALgLKofTmeZvoZ1y/fSZg7R9jPMix8eVA6DH4o/q8=\"; pin-sha256=\"cAajgxHlj7GTSEIzIYIQxmEloOSoJq7VOaxWHfv72QM=\"; pin-sha256=\"SVqWumuteCQHvVIaALrOZXuzVVVeS7f4FGxxu6V+es4=\"; pin-sha256=\"UZJDjsNp1+4M5x9cbbdflB779y5YRBcV6Z6rBMLIrO4=\"; pin-sha256=\"JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=\"; pin-sha256=\"lnsM2T/O9/J84sJFdnrpsFp3awZJ+ZZbYpCWhGloaHI=\"; pin-sha256=\"h6801m+z8v3zbgkRHpq6L29Esgfzhj89C1SyUCOQmqU=\"; pin-sha256=\"SQVGZiOrQXi+kqxcvWWE96HhfydlLVqFr4lQTqI5qqo=\"; pin-sha256=\"q5hJUnat8eyv8o81xTBIeB5cFxjaucjmelBPT2pRMo8=\"; pin-sha256=\"vPtEqrmtAhAVcGtBIep2HIHJ6IlnWQ9vlK50TciLePs=\"; pin-sha256=\"lpkiXF3lLlbN0y3y6W0c/qWqPKC7Us2JM8I7XCdEOCA=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""},
+        {"Expect-CT",
+        "max-age=31536000; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""}
+      ],
+      request_url: "https://query.yahooapis.com/v1/public/yql?q=SELECT%20units,%20location,%20item%20FROM%20weather.forecast%20WHERE%20woeid%20in%20(SELECT%20woeid%20FROM%20geo.places(1)%20WHERE%20text=%22boston%22)&format=json",
+      status_code: 200
+    }
+  end
+end

--- a/travelpal/lib/travelpal_web/router.ex
+++ b/travelpal/lib/travelpal_web/router.ex
@@ -4,6 +4,7 @@ defmodule TravelpalWeb.Router do
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
+    plug :get_current_user
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
@@ -11,6 +12,13 @@ defmodule TravelpalWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+  end
+
+  def get_current_user(conn, _params) do
+    user_id = get_session(conn, :user_id)
+    user = Travelpal.Accounts.get_user(user_id || -1)
+
+    assign(conn, :current_user, user)
   end
 
   scope "/", TravelpalWeb do
@@ -22,6 +30,12 @@ defmodule TravelpalWeb.Router do
     get "/profile", PageController, :index
   end
 
+  scope "/api/v1", TravelpalWeb do
+    pipe_through :api
+
+    resources "/users", UserController
+  end
+
   # Other scopes may use custom stacks.
   scope "/api/v1", TravelpalWeb do
     pipe_through :api
@@ -29,5 +43,8 @@ defmodule TravelpalWeb.Router do
     resources "/traveldates", TravelDateController, except: [:new, :edit]
     resources "/friends", FriendController, except: [:new, :edit]
     post "/token", TokenController, :create
+
+    get "/weather/:city", WeatherController, :get_weather_by_city
+    get "/travel/flights", FlightController, :get_flights_to_from
   end
 end

--- a/travelpal/lib/travelpal_web/router.ex
+++ b/travelpal/lib/travelpal_web/router.ex
@@ -4,7 +4,6 @@ defmodule TravelpalWeb.Router do
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
-    plug :get_current_user
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
@@ -14,13 +13,6 @@ defmodule TravelpalWeb.Router do
     plug :accepts, ["json"]
   end
 
-  def get_current_user(conn, _params) do
-    user_id = get_session(conn, :user_id)
-    user = Travelpal.Accounts.get_user(user_id || -1)
-
-    assign(conn, :current_user, user)
-  end
-
   scope "/", TravelpalWeb do
     pipe_through :browser # Use the default browser stack
 
@@ -28,12 +20,6 @@ defmodule TravelpalWeb.Router do
     get "/travel/dates", PageController, :index
     get "/travel/past", PageController, :index
     get "/profile", PageController, :index
-  end
-
-  scope "/api/v1", TravelpalWeb do
-    pipe_through :api
-
-    resources "/users", UserController
   end
 
   # Other scopes may use custom stacks.

--- a/travelpal/lib/travelpal_web/views/flight_view.ex
+++ b/travelpal/lib/travelpal_web/views/flight_view.ex
@@ -1,0 +1,20 @@
+defmodule TravelpalWeb.FlightView do
+  use TravelpalWeb, :view
+  alias TravelpalWeb.FlightView
+
+  def render("index.json", %{flights: flights}) do
+    %{data: render_many(flights, FlightView, "flight.json")}
+  end
+
+  def render("show.json", %{flight: flight}) do
+    %{data: render_one(flight, FlightView, "flight.json")}
+  end
+
+  def render("flight.json", %{flight: flight}) do
+    decoded_flight = Poison.decode!(flight)
+
+    %{
+      flights: decoded_flight,
+    }
+  end
+end

--- a/travelpal/lib/travelpal_web/views/weather_view.ex
+++ b/travelpal/lib/travelpal_web/views/weather_view.ex
@@ -1,0 +1,22 @@
+defmodule TravelpalWeb.WeatherView do
+  use TravelpalWeb, :view
+  alias TravelpalWeb.WeatherView
+
+  def render("index.json", %{weathers: weathers}) do
+    %{data: render_many(weathers, WeatherView, "weather.json")}
+  end
+
+  def render("show.json", %{weather: weather}) do
+    %{data: render_one(weather, WeatherView, "weather.json")}
+  end
+
+  def render("weather.json", %{weather: weather}) do
+    decoded_weather = Poison.decode!(weather)
+
+    %{
+      units: decoded_weather["units"],
+      location: decoded_weather["location"],
+      item: decoded_weather["item"],
+    }
+  end
+end

--- a/travelpal/mix.exs
+++ b/travelpal/mix.exs
@@ -43,7 +43,10 @@ defmodule Travelpal.Mixfile do
       {:cowboy, "~> 1.0"},
       {:distillery, "~> 1.4"},
       {:comeonin, "~> 4.0"},
-      {:argon2_elixir, "~> 1.2"}
+      {:argon2_elixir, "~> 1.2"},
+      {:httpoison, "~> 1.1"},
+      {:poison, "~> 3.1"},
+      {:hackney, "~> 1.12"},
     ]
   end
 

--- a/travelpal/mix.lock
+++ b/travelpal/mix.lock
@@ -1,5 +1,6 @@
 %{
   "argon2_elixir": {:hex, :argon2_elixir, "1.2.14", "0fc4bfbc1b7e459954987d3d2f3836befd72d63f3a355e3978f5005dd6e80816", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "comeonin": {:hex, :comeonin, "4.1.1", "c7304fc29b45b897b34142a91122bc72757bc0c295e9e824999d5179ffc08416", [:mix], [{:argon2_elixir, "~> 1.2", [hex: :argon2_elixir, repo: "hexpm", optional: true]}, {:bcrypt_elixir, "~> 0.12.1 or ~> 1.0", [hex: :bcrypt_elixir, repo: "hexpm", optional: true]}, {:pbkdf2_elixir, "~> 0.12", [hex: :pbkdf2_elixir, repo: "hexpm", optional: true]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
@@ -11,7 +12,13 @@
   "elixir_make": {:hex, :elixir_make, "0.4.1", "6628b86053190a80b9072382bb9756a6c78624f208ec0ff22cb94c8977d80060", [:mix], [], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.4", "f0bdda195c0e46e987333e986452ec523aed21d784189144f647c43eaf307064", [:mix], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.15.0", "40a2b8ce33a80ced7727e36768499fc9286881c43ebafccae6bab731e2b2b8ce", [:mix], [], "hexpm"},
+  "hackney": {:hex, :hackney, "1.12.1", "8bf2d0e11e722e533903fe126e14d6e7e94d9b7983ced595b75f532e04b7fdc7", [:rebar3], [{:certifi, "2.3.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.1", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
+  "httpoison": {:hex, :httpoison, "1.1.0", "497949fb62924432f64a45269d20e6f61ecf35084ffa270917afcdb7cd4d8061", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
+  "idna": {:hex, :idna, "5.1.1", "cbc3b2fa1645113267cc59c760bafa64b2ea0334635ef06dbac8801e42f7279c", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
+  "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
   "phoenix": {:hex, :phoenix, "1.3.2", "2a00d751f51670ea6bc3f2ba4e6eb27ecb8a2c71e7978d9cd3e5de5ccf7378bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.3 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_ecto": {:hex, :phoenix_ecto, "3.3.0", "702f6e164512853d29f9d20763493f2b3bcfcb44f118af2bc37bb95d0801b480", [:mix], [{:ecto, "~> 2.1", [hex: :ecto, repo: "hexpm", optional: false]}, {:phoenix_html, "~> 2.9", [hex: :phoenix_html, repo: "hexpm", optional: true]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_html": {:hex, :phoenix_html, "2.11.1", "77b6f7fbd252168c6ec4f573de648d37cc5258cda13266ef001fbf99267eb6f3", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
@@ -22,4 +29,6 @@
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.13.5", "3d931aba29363e1443da167a4b12f06dcd171103c424de15e5f3fc2ba3e6d9c5", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
## Weather
- Route: /api/v1/weather/:city
  - Example: http://localhost:4000/api/v1/weather/boston
- Returns weather info in JSON format for a specified city
  - Currently returns weather units, location, and forecast details (can be fine-tuned later)
  - Set to return dummy data for now as to not use up API calls while testing

## Flight
- Route: /api/v1/travel/flights
  - Use query string to attach parameters for the search (origin, dest, date_from, return_from)
  - Example: http://localhost:4000/api/v1/travel/flights?origin=BOS&dest=LAX&date_from=05%2F08%2F2018&return_from=05%2F12%2F2018
- Returns the top 5 flights info in JSON format for a specified trip
  - Currently returns flight airlines, origin location, destination location, duration, price, and a link to the flight
  - Set to return dummy data

## Notes
- This is currently just retrieving the data on-demand for each call. I'll look into retrieving the data in big chunks and storing it in the database for popular trips.
- Weather info for popular locations can probably be stored too, but the forecast only includes the next 5 days I think.
- I can add more functions for data retrieving if you guys want more customized searches.
- Not sure if this is the best practice for making these API calls, so let me know if anything's wrong.

## TODO
- Map airline codes to airline names